### PR TITLE
[v2.0.0] Fix headless automatic execution crashes

### DIFF
--- a/iVS3D/src/iVS3D-core/model/automaticExecution/automaticexecutor.cpp
+++ b/iVS3D/src/iVS3D-core/model/automaticExecution/automaticexecutor.cpp
@@ -35,7 +35,7 @@ void AutomaticExecutor::startMultipleAlgo(QList<QPair<QString, QMap<QString, QVa
     //Set settings of the current plugin
     QMap<QString, QVariant> settings = algoList[step].second;
     if (settings.isEmpty()) {
-        connect(m_algoExec, &AlgorithmExecutor::sig_pluginFinished, this, &AutomaticExecutor::slot_settingsFinished, Qt::DirectConnection);
+        connect(m_algoExec, &AlgorithmExecutor::sig_pluginFinished, this, &AutomaticExecutor::slot_settingsFinished);
         m_algoExec->startGenerateSettings(idx);
     }
     else {
@@ -78,7 +78,9 @@ void AutomaticExecutor::slot_samplingFinished()
     // disconnect so that for example generateSettings can use them
     QObject::disconnect(m_algoExec, &AlgorithmExecutor::sig_pluginFinished, this, &AutomaticExecutor::slot_samplingFinished);
     QObject::disconnect(m_algoExec, &AlgorithmExecutor::sig_algorithmAborted, this, &AutomaticExecutor::slot_algoAbort);
-    QObject::disconnect(m_exportController, &ExportController::sig_exportFinished, this, &AutomaticExecutor::slot_samplingFinished);
+    if (m_exportController) {
+        QObject::disconnect(m_exportController, &ExportController::sig_exportFinished, this, &AutomaticExecutor::slot_samplingFinished);
+    }
 
     if (m_step < m_stepCount) {
        startMultipleAlgo(m_pluginOrder, m_step);
@@ -123,7 +125,7 @@ int AutomaticExecutor::stepToPluginIndex(int step)
 void AutomaticExecutor::executeSampling()
 {
     // connecting the AlgorithmExecuter for sampling usage
-    connect(m_algoExec, &AlgorithmExecutor::sig_pluginFinished, this, &AutomaticExecutor::slot_samplingFinished, Qt::DirectConnection);
+    connect(m_algoExec, &AlgorithmExecutor::sig_pluginFinished, this, &AutomaticExecutor::slot_samplingFinished);
     connect(m_algoExec, &AlgorithmExecutor::sig_algorithmAborted, this, &AutomaticExecutor::slot_algoAbort);
 
     //start the plugin using keyframes, only the first plugin uses all images
@@ -150,7 +152,7 @@ void AutomaticExecutor::executeExport(QMap<QString, QVariant> settings)
         m_exportRunner = new noUIExport(exportProgress, settings, m_dm);
         connect(exportProgress, &Progressable::sig_message, m_terminal, &TerminalInteraction::slot_displayMessage);
         connect(exportProgress, &Progressable::sig_progress, m_terminal, &TerminalInteraction::slot_displayProgress);
-        connect(m_exportRunner, &noUIExport::sig_exportFinished, this, &AutomaticExecutor::slot_samplingFinished, Qt::DirectConnection);
+        connect(m_exportRunner, &noUIExport::sig_exportFinished, this, &AutomaticExecutor::slot_samplingFinished);
         m_exportRunner->runExport();
     }
     m_step++;

--- a/iVS3D/src/iVS3D-core/model/automaticExecution/automaticexecutor.h
+++ b/iVS3D/src/iVS3D-core/model/automaticExecution/automaticexecutor.h
@@ -98,13 +98,13 @@ private:
     int stepToPluginIndex(int step);
     void executeSampling();
     void executeExport(QMap<QString, QVariant> settings);
-    DataManager *m_dm;
-    AlgorithmExecutor* m_algoExec;
+    DataManager *m_dm = nullptr;
+    AlgorithmExecutor* m_algoExec = nullptr;
     int m_step = 0;
     int m_stepCount;
     QList<QPair<QString, QMap<QString, QVariant>>> m_pluginOrder;
-    AutomaticExecSettings *m_autoSettings;
-    ExportController *m_exportController;
+    AutomaticExecSettings *m_autoSettings = nullptr;
+    ExportController *m_exportController = nullptr;
     bool m_isFinished = false;
     noUIExport *m_exportRunner = nullptr;
 

--- a/iVS3D/src/iVS3D-core/model/export/exportexecutor.cpp
+++ b/iVS3D/src/iVS3D-core/model/export/exportexecutor.cpp
@@ -15,12 +15,7 @@ void ExportExecutor::startExport(const ExportConfig& config, LogFile *logFile){
     // cause mip loses its boundary attribute in a magical and unkown way
     mip->setBoundaries(m_boundaries);
     m_exportThread = new ExportThread(this, mip, config, &m_stopped, logFile);
-    if (qApp->property(stringContainer::UIIdentifier).toBool()) {
-        connect(m_exportThread, &ExportThread::finished, this, &ExportExecutor::slot_finished);
-    }
-    else {
-        connect(m_exportThread, &ExportThread::finished, this, &ExportExecutor::slot_finished, Qt::DirectConnection);
-    }
+    connect(m_exportThread, &ExportThread::finished, this, &ExportExecutor::slot_finished);
     m_exportThread->start();
     emit sig_exportStarted();
 }

--- a/iVS3D/src/iVS3D-core/model/export/exportthread.cpp
+++ b/iVS3D/src/iVS3D-core/model/export/exportthread.cpp
@@ -142,8 +142,10 @@ void ExportThread::run() {
 
     // start the computation in multiple worker threads
     QFutureSynchronizer<void> synchronizer;
-    // use all available threads for now
-    int n_threads = QThread::idealThreadCount();
+    // ITransform plugins are stateful and may wrap non-thread-safe inference
+    // engines. Keep transformed exports serialized instead of sharing a
+    // transform instance across concurrent workers.
+    int n_threads = m_config.transformations.empty() ? QThread::idealThreadCount() : 1;
     std::vector<int> n_imgs_exported(n_threads, 0);
 
     for (int i = 0; i < n_threads; i++) {

--- a/iVS3D/src/iVS3D-core/model/export/nouiexport.cpp
+++ b/iVS3D/src/iVS3D-core/model/export/nouiexport.cpp
@@ -101,10 +101,10 @@ void noUIExport::runExport()
 
 
     m_exportExec = new ExportExecutor(this, m_dataManager);
-    connect(m_exportExec, &ExportExecutor::sig_exportFinished, this, &noUIExport::slot_exportFinished, Qt::DirectConnection);
+    connect(m_exportExec, &ExportExecutor::sig_exportFinished, this, &noUIExport::slot_exportFinished);
 
-    connect(m_exportExec,&ExportExecutor::sig_progress, this, &noUIExport::slot_displayProgress, Qt::DirectConnection);
-    connect(m_exportExec, &ExportExecutor::sig_message, this, &noUIExport::slot_displayMessage, Qt::DirectConnection);
+    connect(m_exportExec,&ExportExecutor::sig_progress, this, &noUIExport::slot_displayProgress);
+    connect(m_exportExec, &ExportExecutor::sig_message, this, &noUIExport::slot_displayMessage);
 
     m_dataManager->createProject(outputName, pathWOimages + "/" + outputName + "-project.json");
 

--- a/iVS3D/src/iVS3D-core/model/sampling/algorithmexecutor.cpp
+++ b/iVS3D/src/iVS3D-core/model/sampling/algorithmexecutor.cpp
@@ -17,15 +17,9 @@ int AlgorithmExecutor::startSampling(int pluginIdx)
     }
 
     m_sampleThread = new SampleThread(this, preparedData.images, &m_stopped, m_pluginIndex, preparedData.useCuda);
-    //Use a direct Connection when no ui is used
-    if (qApp->property(stringContainer::UIIdentifier).toBool()) {
-        QObject::connect(m_sampleThread, &QThread::finished, this, &AlgorithmExecutor::slot_pluginFinished);
-    }
-    else {
-        QObject::connect(m_sampleThread, &QThread::finished, this, &AlgorithmExecutor::slot_pluginFinished, Qt::DirectConnection);
-    }
-    m_sampleThread->start();
     m_currentThread = m_sampleThread;
+    QObject::connect(m_sampleThread, &QThread::finished, this, &AlgorithmExecutor::slot_pluginFinished);
+    m_sampleThread->start();
     return 0;
 }
 
@@ -35,15 +29,9 @@ int AlgorithmExecutor::startGenerateSettings(int pluginIdx)
     ALGO_DATA preparedData = prepareAlgoStart(pluginIdx);
     m_settingsThread = new SettingsThread(this, preparedData.images, &m_stopped, m_pluginIndex, preparedData.useCuda);
 
-    //Use a direct Connection when no ui is used
-    if (qApp->property(stringContainer::UIIdentifier).toBool()) {
-        QObject::connect(m_settingsThread, &QThread::finished, this, &AlgorithmExecutor::slot_pluginFinished);
-    }
-    else {
-        QObject::connect(m_settingsThread, &QThread::finished, this, &AlgorithmExecutor::slot_pluginFinished, Qt::DirectConnection);
-    }
-    m_settingsThread->start();
     m_currentThread = m_settingsThread;
+    QObject::connect(m_settingsThread, &QThread::finished, this, &AlgorithmExecutor::slot_pluginFinished);
+    m_settingsThread->start();
     return 0;
 }
 
@@ -58,6 +46,8 @@ void AlgorithmExecutor::slot_abort()
     m_currentThread->wait();
     delete m_currentThread;
     m_currentThread = nullptr;
+    m_sampleThread = nullptr;
+    m_settingsThread = nullptr;
     emit sig_algorithmAborted();
 }
 
@@ -65,6 +55,9 @@ void AlgorithmExecutor::slot_abort()
 
 void AlgorithmExecutor::slot_pluginFinished()
 {
+    const int finishedPluginIndex = m_pluginIndex;
+    QThread *finishedThread = m_currentThread;
+
     if (m_currentThread == m_sampleThread) {
         // if sampling finished set new parameters in DataManager
         std::vector<uint> keyframes = m_sampleThread->getOutput();
@@ -89,7 +82,18 @@ void AlgorithmExecutor::slot_pluginFinished()
         AlgorithmManager::instance().setSettings(m_pluginIndex, generatedSettings);
     }
 
-    emit sig_pluginFinished(m_pluginIndex);
+    if (finishedThread) {
+        finishedThread->deleteLater();
+    }
+    if (finishedThread == m_sampleThread) {
+        m_sampleThread = nullptr;
+    }
+    if (finishedThread == m_settingsThread) {
+        m_settingsThread = nullptr;
+    }
+    m_currentThread = nullptr;
+
+    emit sig_pluginFinished(finishedPluginIndex);
 }
 
 ALGO_DATA AlgorithmExecutor::prepareAlgoStart(int pluginIdx)


### PR DESCRIPTION
## Summary

This patch fixes crashes in iVS3D v2.0.0 when running automatic execution in `--nogui` mode with a multi-step settings file.

The affected headless chain is:

`Blur -> SmoothCameraMovement -> VisualSimilarity -> Export with semantic segmentation masks`

## Root cause

The v2.0.0 headless path forced `Qt::DirectConnection` for plugin/export completion signals. That allowed completion handlers to mutate automatic-execution and export state from worker threads instead of returning to the main event loop.

There were two related stability issues:

- `AutomaticExecutor::m_exportController` was used during headless cleanup even though it is only initialized for GUI export flows.
- Transform-enabled export shared one stateful `ITransform`/ONNX-backed transform instance across multiple export worker threads, which made semantic-segmentation export unsafe.

## Changes

- Use queued/default Qt signal delivery for plugin/export completion instead of forcing worker-thread callbacks in no-GUI mode.
- Initialize and guard GUI-only executor pointers before disconnecting them.
- Clear finished sampling/settings thread pointers before starting the next automatic step.
- Serialize transform-enabled exports so stateful transform plugins are not shared across concurrent export workers.

## Reproduction

Create a settings file such as `auto-settings.json`:

```json
{
  "0": { "Blur": {} },
  "1": { "SmoothCameraMovement": {} },
  "2": { "VisualSimilarity": {} },
  "3": {
    "Export": {
      "Resolution": "1280x720",
      "Format": "png",
      "use ROI": false,
      "use ITransform": [true],
      "ITransform settings": [
        {
          "Used Model": "Segmentation_BiseNetV2_Aerial.onnx",
          "Selected classes": [false, false, false, true, true, false]
        }
      ]
    }
  }
}
```

Run iVS3D v2.0.0 against any short MP4/video input with the bundled plugins and semantic-segmentation model available:

```powershell
iVS3D-core.exe --nogui -a auto-settings.json -i sample.mp4 -o output -l logs
```

Before this patch, the process can crash with an access violation during automatic step transitions or semantic-mask export. With this patch, the same command completes without user interaction and writes the selected frames, masks, project file, and logs.

## Compatibility note

This branch is intentionally based on tag `v2.0.0`, because that is the released version where the crash was reproduced and fixed. The current `master` branch has refactored the affected automatic execution/sampling/export classes for v2.1.0, so this patch is not directly mergeable into `master` without porting the fix to the new architecture.