### PR TITLE
Add headless CLI automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ https://github.com/user-attachments/assets/1f0c93f8-5e52-4436-a95e-5b9e3b7ea11d
 
 To get started quickly, download a [prebuilt binary](#-ready-to-use-builds) from our releases and follow our [tutorial](doc/tutorial.md).
 
+For batch processing without opening the GUI, see the [headless CLI automation guide](doc/headless_cli.md).
+
 ## 🔍 Plugins 🧮
 
 There are currently 8 plugins implemented:

--- a/doc/headless_cli.md
+++ b/doc/headless_cli.md
@@ -1,0 +1,121 @@
+# Headless CLI automation
+
+iVS3D can run a configured sampling and export pipeline without opening the GUI.
+This is useful for repeatable batch processing and server environments.
+
+## Command
+
+```bash
+iVS3D-core --nogui -a auto-settings.json -i sample.mp4 -m sample.srt -o output -l logs
+```
+
+The required arguments are:
+
+- `--nogui`: run without creating the main window.
+- `-a, --auto`: path to the headless settings JSON file.
+- `-i, --in`: path to an input video or image sequence.
+- `-o, --out`: output directory used by export steps.
+
+The optional `-m, --metadata` argument imports metadata files such as SRT, GPX,
+or TXT before running the configured steps. It can be passed multiple times, for
+example `-m flight.srt -m track.gpx`. If explicit metadata files are provided,
+all paths must exist and at least one metadata feature must be detected.
+
+Metadata examples:
+
+```bash
+iVS3D-core --nogui -i sample.mp4 -a auto-settings.json -m flight.srt -o output
+iVS3D-core --nogui -i sample.mp4 -a auto-settings.json -m track.gpx -o output
+iVS3D-core --nogui -i sample.mp4 -a auto-settings.json -m positions.txt -o output
+```
+
+The optional `-l, --log` argument writes process logs to the given directory.
+
+## Minimal settings
+
+The settings file contains an ordered `steps` array. This example selects every
+tenth input frame and exports the resulting image set as PNG files:
+
+```json
+{
+  "steps": [
+    {
+      "type": "selection",
+      "plugin": "Nth image selection",
+      "settings": {
+        "N": 10,
+        "KeepIsolated": false
+      }
+    },
+    {
+      "type": "export",
+      "settings": {
+        "format": "png"
+      }
+    }
+  ]
+}
+```
+
+Headless mode uses English plugin names so settings files are portable across
+systems with different GUI locales.
+
+## Step types
+
+### Selection
+
+Selection steps run an image-selection plugin and replace the current selection
+with the plugin result.
+
+```json
+{
+  "type": "selection",
+  "plugin": "Nth image selection",
+  "settings": {
+    "N": 10,
+    "KeepIsolated": false
+  }
+}
+```
+
+The `plugin` value must match a plugin that supports image selection. The
+`settings` object is passed to the plugin by key.
+
+### Mask
+
+Mask steps add a mask-generation plugin to the export mask stack.
+
+```json
+{
+  "type": "mask",
+  "plugin": "Segmentation Masks",
+  "settings": {
+    "selectedModel": {
+      "name": "model-name",
+      "modelConfigPath": "path/to/model-config.json"
+    }
+  }
+}
+```
+
+The exact settings depend on the selected plugin. For segmentation, provide a
+model configuration that is available on the machine running iVS3D.
+
+### Export
+
+Export steps write the current image selection and configured masks.
+
+```json
+{
+  "type": "export",
+  "settings": {
+    "path": "output",
+    "resolution": "1920x1080",
+    "format": "png"
+  }
+}
+```
+
+Export settings are optional. If `path` is omitted, `-o, --out` is used. If
+`resolution` is omitted, the original input resolution is used. If `format` is
+omitted, PNG files are written.

--- a/iVS3D/src/iVS3D-core/controller/headlesscontroller.cpp
+++ b/iVS3D/src/iVS3D-core/controller/headlesscontroller.cpp
@@ -1,0 +1,412 @@
+#include "headlesscontroller.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QMetaObject>
+#include <QTextStream>
+#include <iostream>
+#include <utility>
+
+#include "applicationsettings.h"
+#include "logmanager.h"
+#include "pluginmanager.h"
+#include "stringcontainer.h"
+
+HeadlessController::HeadlessController(QString inputPath, QString settingsPath,
+                                       QString outputPath, QString logPath,
+                                       QStringList metadataPaths,
+                                       QObject* parent)
+    : QObject(parent),
+      m_inputPath(std::move(inputPath)),
+      m_settingsPath(std::move(settingsPath)),
+      m_outputPath(std::move(outputPath)),
+      m_logPath(std::move(logPath)),
+      m_metadataPaths(std::move(metadataPaths)) {
+    start();
+}
+
+void HeadlessController::start() {
+    const QString inputError = requirePath(m_inputPath, "input");
+    if (!inputError.isEmpty()) {
+        exitWithFail(inputError);
+        return;
+    }
+
+    const QString settingsError = requirePath(m_settingsPath, "settings");
+    if (!settingsError.isEmpty()) {
+        exitWithFail(settingsError);
+        return;
+    }
+
+    if (m_outputPath.isEmpty()) {
+        exitWithFail("Missing output path. Use -o/--out in headless mode.");
+        return;
+    }
+
+    for (const QString& metadataPath : m_metadataPaths) {
+        const QString metadataError = requirePath(metadataPath, "metadata");
+        if (!metadataError.isEmpty()) {
+            exitWithFail(metadataError);
+            return;
+        }
+    }
+
+    if (!m_logPath.isEmpty()) {
+        LogManager::instance().setLogDirectory(m_logPath);
+    }
+
+    QString error;
+    if (!loadSettings(&error)) {
+        exitWithFail(error);
+        return;
+    }
+
+    PluginManager::instance().enableCuda(ApplicationSettings::instance().getUseCuda());
+    m_pluginThread = PluginManager::instance().getPluginThread();
+    m_maskStack = std::make_shared<MaskStack>();
+
+    const int imageCount = m_dataManager.open(m_inputPath);
+    if (imageCount <= 0 || !m_dataManager.getModelInputPictures() ||
+        !m_dataManager.getModelInputPictures()->getReader()) {
+        exitWithFail(QString("Failed to open input: %1").arg(m_inputPath));
+        return;
+    }
+
+    auto* reader = m_dataManager.getModelInputPictures()->getReader();
+    m_pluginThread->onInputLoaded(reader);
+
+    if (!loadExplicitMetadata(&error)) {
+        exitWithFail(error);
+        return;
+    }
+
+    if (auto* md = reader->getMetaData()) {
+        m_pluginThread->onMetaDataLoaded(PLUG::InputMetaData{md});
+    }
+    m_pluginThread->onSelectedImagesChanged(
+        m_dataManager.getModelInputPictures()->getAllKeyframes(true));
+
+    runNextStep();
+}
+
+bool HeadlessController::loadSettings(QString* error) {
+    QFile file(m_settingsPath);
+    if (!file.open(QFile::ReadOnly | QFile::Text)) {
+        *error = QString("Failed to open settings file: %1").arg(m_settingsPath);
+        return false;
+    }
+
+    QJsonParseError parseError;
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &parseError);
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+        *error = QString("Invalid settings JSON: %1").arg(parseError.errorString());
+        return false;
+    }
+
+    const QJsonValue stepsValue = doc.object().value("steps");
+    if (!stepsValue.isArray()) {
+        *error = "Headless settings must contain a 'steps' array.";
+        return false;
+    }
+
+    const QJsonArray steps = stepsValue.toArray();
+    if (steps.isEmpty()) {
+        *error = "Headless settings must contain at least one step.";
+        return false;
+    }
+
+    for (const QJsonValue& value : steps) {
+        if (!value.isObject()) {
+            *error = "Every headless settings step must be an object.";
+            return false;
+        }
+
+        Step step;
+        if (!parseStep(value.toObject(), &step, error)) {
+            return false;
+        }
+        m_steps.append(step);
+    }
+
+    return true;
+}
+
+bool HeadlessController::loadExplicitMetadata(QString* error) {
+    if (m_metadataPaths.isEmpty()) {
+        return true;
+    }
+
+    const int metadataCount =
+        m_dataManager.getModelInputPictures()->loadMetaData(m_metadataPaths);
+    if (metadataCount <= 0) {
+        *error = "No metadata features were detected in the provided metadata files.";
+        return false;
+    }
+
+    std::cout << "Loaded " << metadataCount << " metadata feature"
+              << (metadataCount == 1 ? "" : "s") << "." << std::endl;
+    return true;
+}
+
+bool HeadlessController::parseStep(const QJsonObject& object, Step* step,
+                                   QString* error) const {
+    const QString type = object.value("type").toString().toLower();
+    if (type == "selection") {
+        step->type = StepType::Selection;
+        step->pluginName = object.value("plugin").toString();
+        if (step->pluginName.isEmpty()) {
+            *error = "Selection step requires a plugin name.";
+            return false;
+        }
+        step->settings = objectToVariantMap(object.value("settings").toObject());
+        return true;
+    }
+
+    if (type == "mask") {
+        step->type = StepType::Mask;
+        step->pluginName = object.value("plugin").toString();
+        if (step->pluginName.isEmpty()) {
+            *error = "Mask step requires a plugin name.";
+            return false;
+        }
+        step->settings = objectToVariantMap(object.value("settings").toObject());
+        return true;
+    }
+
+    if (type == "export") {
+        step->type = StepType::Export;
+        step->exportSettings = object.value("settings").toObject();
+        return true;
+    }
+
+    *error = QString("Unsupported headless step type: %1").arg(type);
+    return false;
+}
+
+void HeadlessController::runNextStep() {
+    if (m_stepIndex >= m_steps.size()) {
+        finish(0);
+        return;
+    }
+
+    const Step step = m_steps.at(m_stepIndex++);
+    switch (step.type) {
+        case StepType::Selection:
+            runSelectionStep(step);
+            break;
+        case StepType::Mask:
+            runMaskStep(step);
+            break;
+        case StepType::Export:
+            runExportStep(step);
+            break;
+    }
+}
+
+void HeadlessController::runSelectionStep(const Step& step) {
+    if (!PluginManager::instance().hasSelectionPlugin(step.pluginName)) {
+        exitWithFail(QString("Plugin does not support selection: %1").arg(step.pluginName));
+        return;
+    }
+
+    const auto applyResult =
+        PluginManager::instance().applyPluginSettings(step.pluginName, step.settings);
+    if (!applyResult) {
+        exitWithFail(QString("Failed to apply settings for %1: %2")
+                 .arg(step.pluginName, applyResult.error().message));
+        return;
+    }
+
+    PLUG::SelectionData data;
+    auto* mip = m_dataManager.getModelInputPictures();
+    data.selectedIndices = mip->getAllKeyframes(true);
+    data.roi = mip->getReaderParams()->getRoi();
+    data.workingResolution = mip->getReaderParams()->getWorkingResolution();
+    data.reader = mip->getReader();
+
+    auto selectionLog = LogManager::instance().createLogFile(step.pluginName, true);
+    if (selectionLog) {
+        selectionLog->setSettings(PluginManager::instance().getPluginSettings(step.pluginName));
+        selectionLog->setInputInfo(data.selectedIndices);
+        data.logFile = selectionLog;
+    }
+
+    m_currentSelectionPlugin = step.pluginName;
+    connect(m_pluginThread.get(), &PluginThread::selectionFinished, this,
+            &HeadlessController::onSelectionFinished, Qt::UniqueConnection);
+    m_pluginThread->requestSelection(step.pluginName, data);
+}
+
+void HeadlessController::onSelectionFinished(const SelectionResultData& result) {
+    if (result.pluginName != m_currentSelectionPlugin) {
+        return;
+    }
+
+    disconnect(m_pluginThread.get(), &PluginThread::selectionFinished, this,
+               &HeadlessController::onSelectionFinished);
+
+    if (result.cancelled) {
+        exitWithFail(QString("Selection cancelled: %1").arg(result.pluginName));
+        return;
+    }
+
+    if (!result.success) {
+        exitWithFail(QString("Selection failed for %1: %2")
+                 .arg(result.pluginName, result.errorMessage));
+        return;
+    }
+
+    m_dataManager.getModelInputPictures()->updateMIP(result.selectedIndices);
+    runNextStep();
+}
+
+void HeadlessController::runMaskStep(const Step& step) {
+    if (!PluginManager::instance().hasMaskPlugin(step.pluginName)) {
+        exitWithFail(QString("Plugin does not support mask generation: %1").arg(step.pluginName));
+        return;
+    }
+
+    const auto applyResult =
+        PluginManager::instance().applyPluginSettings(step.pluginName, step.settings);
+    if (!applyResult) {
+        exitWithFail(QString("Failed to apply settings for %1: %2")
+                 .arg(step.pluginName, applyResult.error().message));
+        return;
+    }
+
+    auto* mip = m_dataManager.getModelInputPictures();
+    MaskRecord record;
+    record.pluginName = step.pluginName;
+    record.pluginSettings = PluginManager::instance().getPluginSettings(step.pluginName);
+    record.pluginSettingsString =
+        PluginManager::instance().getPluginSettingsString(step.pluginName);
+    record.workingResolution = mip->getReaderParams()->getWorkingResolution();
+    record.roi = mip->getReaderParams()->getUseRoi()
+                     ? mip->getReaderParams()->getRoi()
+                     : ROI();
+    m_maskStack->addRecord(record);
+    runNextStep();
+}
+
+void HeadlessController::runExportStep(const Step& step) {
+    QDir exportDir;
+    QString path = m_outputPath;
+    if (step.exportSettings.contains("path")) {
+        path = step.exportSettings.value("path").toString(path);
+    }
+    path.replace("\\", "/");
+    if (path.endsWith("/")) {
+        path.chop(1);
+    }
+    if (!exportDir.mkpath(path)) {
+        exitWithFail(QString("Failed to create output directory: %1").arg(path));
+        return;
+    }
+
+    QString outputName = QFileInfo(path).fileName();
+    QString imagePath = path;
+    if (!imagePath.endsWith("/images")) {
+        imagePath += "/images";
+    } else {
+        QDir parent(path);
+        parent.cdUp();
+        outputName = parent.dirName();
+        path = parent.absolutePath();
+        imagePath = path + "/images";
+    }
+    QDir().mkpath(imagePath);
+
+    auto* mip = m_dataManager.getModelInputPictures();
+    auto readerParams = mip->getReaderParams();
+    Resolution exportResolution = readerParams->getOriginalResolution();
+    const QString resolutionString = step.exportSettings.value("resolution").toString();
+    if (!resolutionString.isEmpty()) {
+        Resolution requested;
+        if (!requested.fromString(resolutionString)) {
+            exitWithFail(QString("Invalid export resolution: %1").arg(resolutionString));
+            return;
+        }
+        exportResolution = requested;
+    }
+
+    ExportConfig config;
+    config.name = outputName;
+    config.destination = imagePath;
+    config.format = step.exportSettings.value("format").toString("png");
+    config.original_resolution = readerParams->getOriginalResolution();
+    config.working_resolution = readerParams->getWorkingResolution();
+    config.export_resolution = exportResolution;
+    config.copy_images = false;
+    config.maskStack = m_maskStack.get();
+    if (readerParams->getUseRoi() && !readerParams->getRoi().isDefault()) {
+        config.roi = readerParams->getRoi();
+    }
+
+    m_dataManager.createProject(outputName, path + "/" + outputName + "-project.json");
+
+    m_exportLog = LogManager::instance().createLogFile("Export", false);
+    if (m_exportLog) {
+        QMap<QString, QVariant> settings;
+        settings.insert(stringContainer::OutputPath, path);
+        settings.insert(stringContainer::Resolution, exportResolution.toString());
+        settings.insert(stringContainer::OutputFormat, config.format);
+        settings.insert(stringContainer::UseROI, config.roi.has_value());
+        m_exportLog->setSettings(settings);
+    }
+
+    m_exportExecutor = new ExportExecutor(this, &m_dataManager, m_pluginThread);
+    connect(m_exportExecutor, &ExportExecutor::sig_exportFinished, this,
+            &HeadlessController::onExportFinished);
+    connect(m_exportExecutor, &ExportExecutor::sig_message, this,
+            [](const QString& message) { std::cout << message.toStdString() << std::endl; });
+    connect(m_exportExecutor, &ExportExecutor::sig_warning, this,
+            [](const QString& warning) { std::cerr << warning.toStdString() << std::endl; });
+    m_exportExecutor->startExport(config, m_exportLog);
+}
+
+void HeadlessController::onExportFinished(ExportResult result) {
+    if (result.type == ExportResultType::Failed) {
+        exitWithFail(QString("Export failed: %1").arg(result.errorMessage));
+        return;
+    }
+
+    if (result.type == ExportResultType::Aborted) {
+        exitWithFail("Export aborted.");
+        return;
+    }
+
+    if (m_exportExecutor) {
+        m_exportExecutor->deleteLater();
+        m_exportExecutor = nullptr;
+    }
+    runNextStep();
+}
+
+void HeadlessController::exitWithFail(const QString& message) {
+    std::cerr << "[ERROR] " << message.toStdString() << std::endl;
+    finish(1);
+}
+
+void HeadlessController::finish(int exitCode) {
+    QMetaObject::invokeMethod(QCoreApplication::instance(),
+                              [exitCode]() { QCoreApplication::exit(exitCode); },
+                              Qt::QueuedConnection);
+}
+
+QString HeadlessController::requirePath(const QString& path, const QString& name) const {
+    if (path.isEmpty()) {
+        return QString("Missing %1 path.").arg(name);
+    }
+    if (!QFileInfo::exists(path)) {
+        return QString("%1 path does not exist: %2").arg(name, path);
+    }
+    return {};
+}
+
+QMap<QString, QVariant> HeadlessController::objectToVariantMap(
+    const QJsonObject& object) const {
+    return object.toVariantMap();
+}

--- a/iVS3D/src/iVS3D-core/controller/headlesscontroller.h
+++ b/iVS3D/src/iVS3D-core/controller/headlesscontroller.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <memory>
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+#include "DataManager.h"
+#include "exportexecutor.h"
+#include "maskstack.h"
+#include "pluginthread.h"
+
+class HeadlessController : public QObject {
+    Q_OBJECT
+
+public:
+    HeadlessController(QString inputPath, QString settingsPath,
+                       QString outputPath, QString logPath,
+                       QStringList metadataPaths = {},
+                       QObject* parent = nullptr);
+
+private slots:
+    void onSelectionFinished(const SelectionResultData& result);
+    void onExportFinished(ExportResult result);
+
+private:
+    enum class StepType { Selection, Mask, Export };
+
+    struct Step {
+        StepType type;
+        QString pluginName;
+        QMap<QString, QVariant> settings;
+        QJsonObject exportSettings;
+    };
+
+    void start();
+    bool loadSettings(QString* error);
+    bool loadExplicitMetadata(QString* error);
+    bool parseStep(const QJsonObject& object, Step* step, QString* error) const;
+    void runNextStep();
+    void runSelectionStep(const Step& step);
+    void runMaskStep(const Step& step);
+    void runExportStep(const Step& step);
+    void exitWithFail(const QString& message);
+    void finish(int exitCode);
+    QString requirePath(const QString& path, const QString& name) const;
+    QMap<QString, QVariant> objectToVariantMap(const QJsonObject& object) const;
+
+    QString m_inputPath;
+    QString m_settingsPath;
+    QString m_outputPath;
+    QString m_logPath;
+    QStringList m_metadataPaths;
+
+    DataManager m_dataManager;
+    std::shared_ptr<PluginThread> m_pluginThread;
+    std::shared_ptr<MaskStack> m_maskStack;
+    ExportExecutor* m_exportExecutor = nullptr;
+    std::shared_ptr<LogFile> m_exportLog;
+
+    QVector<Step> m_steps;
+    int m_stepIndex = 0;
+    QString m_currentSelectionPlugin;
+};

--- a/iVS3D/src/iVS3D-core/main.cpp
+++ b/iVS3D/src/iVS3D-core/main.cpp
@@ -9,6 +9,7 @@
 
 #include "controller.h"
 #include "cvmat_qmetadata.h"
+#include "headlesscontroller.h"
 #include "stringcontainer.h"
 #include "view/darkstyle/DarkStyle.h"
 #include "view/mainwindow.h"
@@ -63,6 +64,11 @@ int main(int argc, char* argv[]) {
     QCommandLineOption logPath(
         QStringList() << "l" << "log",
         "Log resulsts and process information to <path>.", "path");
+    QCommandLineOption metadataPath(
+        QStringList() << "m" << "metadata",
+        "Load additional metadata from <path> in headless mode.", "path");
+    QCommandLineOption noGui(QStringList() << "nogui",
+                             "Run the configured pipeline without showing the GUI.");
 
     parser.setApplicationDescription(
         "intelligent video sampler 3d is designed to process image sequences "
@@ -81,6 +87,8 @@ int main(int argc, char* argv[]) {
     parser.addOption(inputPath);
     parser.addOption(outputPath);
     parser.addOption(logPath);
+    parser.addOption(metadataPath);
+    parser.addOption(noGui);
 
     QStringList arguments;
     for (int i = 0; i < argc; ++i) {
@@ -92,9 +100,11 @@ int main(int argc, char* argv[]) {
     a.setApplicationName("iVS3D");
     a.setApplicationVersion(QString(QUOTE(IVS3D_VER)));
     parser.process(a);
-    qApp->setProperty(stringContainer::UIIdentifier, true);
+    const bool headless = parser.isSet(noGui);
+    qApp->setProperty(stringContainer::UIIdentifier, !headless);
     qApp->setProperty("translation",
-                      ApplicationSettings::instance().getLocale());
+                      headless ? QLocale(QLocale::English)
+                               : ApplicationSettings::instance().getLocale());
     qDebug() << "Locale: " << qApp->property("translation").toLocale();
     QTranslator* translator = new QTranslator();
     translator->load(qApp->property("translation").toLocale(), "core", "_",
@@ -115,9 +125,17 @@ int main(int argc, char* argv[]) {
     }
     qDebug() << "Library search paths: " << QApplication::libraryPaths();
 #endif
-    Controller* mainController =
-        new Controller(parser.value(inputPath), parser.value(autoPath),
-                       parser.value(outputPath), parser.value(logPath));
+    QObject* mainController = nullptr;
+    if (headless) {
+        mainController = new HeadlessController(
+            parser.value(inputPath), parser.value(autoPath),
+            parser.value(outputPath), parser.value(logPath),
+            parser.values(metadataPath));
+    } else {
+        mainController =
+            new Controller(parser.value(inputPath), parser.value(autoPath),
+                           parser.value(outputPath), parser.value(logPath));
+    }
 
     auto res = a.exec();
     delete mainController;

--- a/iVS3D/src/iVS3D-core/model/export/exportexecutor.cpp
+++ b/iVS3D/src/iVS3D-core/model/export/exportexecutor.cpp
@@ -38,12 +38,7 @@ void ExportExecutor::startExport(const ExportConfig& config, std::shared_ptr<Log
     // cause mip loses its boundary attribute in a magical and unkown way
     mip->setBoundaries(m_boundaries);
     m_exportThread = new ExportThread(this, mip, config, &m_stopped, logFile, m_pluginThread.get());
-    if (qApp->property(stringContainer::UIIdentifier).toBool()) {
-        connect(m_exportThread, &ExportThread::finished, this, &ExportExecutor::slot_finished);
-    }
-    else {
-        connect(m_exportThread, &ExportThread::finished, this, &ExportExecutor::slot_finished, Qt::DirectConnection);
-    }
+    connect(m_exportThread, &ExportThread::finished, this, &ExportExecutor::slot_finished);
     m_exportThread->start();
     emit sig_exportStarted();
 }


### PR DESCRIPTION
﻿## Summary

Adds a supported headless automation path for iVS3D so a sampling/export pipeline can run from the CLI without showing the main window.

- adds `--nogui` and routes CLI execution through a new `HeadlessController`
- loads input, applies ordered selection and mask steps, and runs export from a JSON settings file
- forces English plugin names in headless mode so settings files are portable across GUI locales
- removes the no-GUI direct export-thread connection that made cleanup run on the worker thread
- documents the headless settings schema and a minimal reproducible command

## Root cause

The existing CLI exposed `-a/--auto`, `-i/--in`, `-o/--out`, and `-l/--log`, but the application still always created the GUI controller and main window. There was no maintained no-window controller that used the current plugin, mask, and export architecture. In addition, plugin names came from the active GUI locale, which made automation settings machine-locale dependent.

## Example

```bash
iVS3D-core --nogui -a auto-settings.json -i sample.mp4 -o output -l logs
```

```json
{
  "steps": [
    {
      "type": "selection",
      "plugin": "Nth image selection",
      "settings": {
        "N": 10,
        "KeepIsolated": false
      }
    },
    {
      "type": "export",
      "settings": {
        "format": "png"
      }
    }
  ]
}
```

## Validation

- Built `iVS3D-core` with the Windows release CMake preset.
- Ran `--nogui` with a generated image-sequence fixture and the documented `Nth image selection -> export` settings. The process exited `0`, exported 5 PNG images, and wrote a JSON log.
- Ran a longer local HEVC video + SRT metadata smoke pipeline with `Nth image selection`, `Blur detection`, `Geo Distance`, `Stationary camera removal`, `Smooth camera movement`, and `export`. The process exited `0`, exported 271 PNG images at 3840 x 2880, and wrote a JSON log.
